### PR TITLE
Add default config that meets singer spec criteria

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,5 +28,11 @@ setup(name="pipelinewise-singer-python",
               'singer-tools'
           ]
       },
-      packages=find_packages(),
+      packages=['singer'],
+      package_data={
+          'singer': [
+              'logging.conf'
+          ]
+      },
+      include_package_data=True
       )

--- a/singer/logger.py
+++ b/singer/logger.py
@@ -5,8 +5,14 @@ import os
 
 def get_logger(name='singer'):
     """Return a Logger instance to use in singer."""
+    # Use custom logging config provided by environment variable
     if 'LOGGING_CONF_FILE' in os.environ and os.environ['LOGGING_CONF_FILE']:
         path = os.environ['LOGGING_CONF_FILE']
+        logging.config.fileConfig(path, disable_existing_loggers=False)
+    # Use the default logging conf that meets the singer specs criteria
+    else:
+        this_dir, _ = os.path.split(__file__)
+        path = os.path.join(this_dir, 'logging.conf')
         logging.config.fileConfig(path, disable_existing_loggers=False)
 
     return logging.getLogger(name)

--- a/singer/logging.conf
+++ b/singer/logging.conf
@@ -1,0 +1,25 @@
+[loggers]
+keys=root
+
+[handlers]
+keys=stderr
+
+[formatters]
+keys=child
+
+[logger_root]
+level=INFO
+handlers=stderr
+formatter=child
+propagate=0
+
+[handler_stderr]
+level=INFO
+class=StreamHandler
+formatter=child
+args=(sys.stderr,)
+
+[formatter_child]
+class=logging.Formatter
+format=time=%(asctime)s name=%(name)s level=%(levelname)s message=%(message)s
+datefmt=%Y-%m-%d %H:%M:%S


### PR DESCRIPTION
# Description of change

Currently if `LOGGER_CONF_FILE` env var not defined then the logger is using the default values and sends logs messages to  `stdout`. This doesn't meet the singer specs and sends log messages to `stdout` together with `RECORD` ,`SCHEMA` and `STATE` control messages. This behaviour makes every tap and target connector unusable if no `LOGGER_CONF_FILE` defined that's logging to `stderr` .

We need to make sure that log messages sent to `STDERR` as defined in the [singer spec](https://github.com/singer-io/getting-started/blob/master/docs/SPEC.md#output):

```
A Tap outputs structured messages to stdout in JSON format, one message per line.
Logs and other information can be emitted to stderr for aiding debugging.
```

This PR adds a minimal built-in default `logging.conf` that sends logs to `stderr` making sure this python library meets the singer specification. 

# Manual QA steps

Running with `LOGGER_CONF_FILE` with custom time format of `datefmt=%Y%m%d%H%M%S`.

Every log message should sent to `stderr` and NOT `stdout` with custom time format:
```
$ export LOGGING_CONF_FILE=sample_logging.conf 
$ cat tests/integration/resources/messages-with-multi-schemas.json | target-snowflake --config config.json > /dev/null
custom time format=20200211104019 name=target_snowflake level=INFO message=Getting catalog objects from information_schema cache table...
custom time format=20200211104021 name=target_snowflake level=INFO message=Table 'test_pk.test_table_one' exists
```

Running without `LOGGER_CONF_FILE`:
Every log message should sent to `stderr` and NOT `stdout` with default time format:
```
$ unset LOGGING_CONF_FILE
$  cat tests/integration/resources/messages-with-multi-schemas.json | target-snowflake --config config.json > /dev/null
time=2020-02-11 10:44:20 name=target_snowflake level=INFO message=Getting catalog objects from information_schema cache table...
time=2020-02-11 10:44:23 name=target_snowflake level=INFO message=Table 'test_pk.test_table_one' exists
...
```
 
# Risks

None
 
# Rollback steps
 - revert this branch
