### PR TITLE
Bump jsonschema to latest

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(name="pipelinewise-singer-python",
       url="https://github.com/transferwise/pipelinewise-singer-python",
       install_requires=[
           'pytz==2019.3',
-          'jsonschema==2.6.0',
+          'jsonschema==3.2.0',
           'simplejson==3.11.1',
           'python-dateutil>=2.6.0',
           'backoff==1.8.0',


### PR DESCRIPTION
# Description of change

Bump `jsonschema-2.6.0` to `jsonschema-3.2.0` because the tests in taps and targets that using this library compaining a deprecation warning:
```
venv/lib/python3.7/site-packages/jsonschema/compat.py:6
venv/lib/python3.7/site-packages/jsonschema/compat.py:6
  /Users/peter.kosztolanyi/workspaces/transferwise/pipelinewise-tap-kafka/venv/lib/python3.7/site-packages/jsonschema/compat.py:6: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
    from collections import MutableMapping, Sequence  # noqa

-- Docs: https://docs.pytest.org/en/latest/warnings.html
```

`jsonschema-2.6.0` is 3 years old and worth to upgrade. It's a major version change
[CHANGELOG](https://github.com/Julian/jsonschema/blob/master/CHANGELOG.rst) but primarily because it's introducing jsonschema Draft6 and Draft7. This should be fine becuase in the target connectors we're explicitly using Draft4 and Drafts6-7 are backward compatibles anyay. 


# Manual QA steps
 - Updated every target connector dependencies to `jsonschema-3.2.0` in their own virtualenvs, ran the tests and everything still passing.
 
# Risks
 - This change automatically flows down to every tap and target connector and into the main PPW.
 
# Rollback steps
 - revert this branch
