### PR TITLE
Bump pytz to 2020.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name="pipelinewise-singer-python",
-      version='1.1.1',
+      version='1.1.2',
       description="Singer.io utility library - PipelineWise compatible",
       long_description=long_description,
       long_description_content_type="text/markdown",
@@ -17,7 +17,7 @@ setup(name="pipelinewise-singer-python",
       ],
       url="https://github.com/transferwise/pipelinewise-singer-python",
       install_requires=[
-          'pytz==2019.3',
+          'pytz==2020.1',
           'jsonschema==2.6.0',
           'simplejson==3.11.1',
           'python-dateutil>=2.6.0',


### PR DESCRIPTION
# Description of change

The downstream PPW fails to install because one of the dependencies requires the unpinned pytz. `pytz-2020.1` is available since 28th April and breaks the install because this package requires an older version of pytz.

Main PPW build error:
```
ERROR: pipelinewise-singer-python 1.1.1 has requirement pytz==2019.3, but you'll have pytz 2020.1 which is incompatible.
```

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
