### PR TITLE
Updated PYTZ Pin to Wider Range

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(name="pipelinewise-singer-python",
       ],
       url="https://github.com/transferwise/pipelinewise-singer-python",
       install_requires=[
-          'pytz==2020.1',
+          'pytz >=2019, <=2021',
           'jsonschema==3.2.0',
           'simplejson==3.11.1',
           'python-dateutil>=2.6.0',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name="pipelinewise-singer-python",
-      version='1.1.3',
+      version='1.1.4',
       description="Singer.io utility library - PipelineWise compatible",
       long_description=long_description,
       long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(name="pipelinewise-singer-python",
       ],
       url="https://github.com/transferwise/pipelinewise-singer-python",
       install_requires=[
-          'pytz <2021.0',
+          'pytz<2021.0',
           'jsonschema==3.2.0',
           'simplejson==3.11.1',
           'python-dateutil>=2.6.0',

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(name="pipelinewise-singer-python",
       ],
       url="https://github.com/transferwise/pipelinewise-singer-python",
       install_requires=[
-          'pytz >=2019, <=2021',
+          'pytz <2021.0',
           'jsonschema==3.2.0',
           'simplejson==3.11.1',
           'python-dateutil>=2.6.0',


### PR DESCRIPTION
# Description of change
The same issue that happened (here)[https://github.com/transferwise/pipelinewise/issues/393] is happening again. Downstream deps conflict with the hard pin at `pytz==2020.1` and several connectors fail to install. 

# Manual QA steps
 - Follow the (Docker build directions)[https://github.com/transferwise/pipelinewise#running-from-docker] in the pipelinewise readme. several of the taps will run into the following dependency error:
```
pipelinewise-singer-python 1.1.3 requires pytz==2020.1, but you'll have pytz 2020.4 which is incompatible.
```
The build will then fail. 
 
# Risks
 - by moving to a minor range we expose the potential of a breaking change being introduced down the line. However, right now this is happening by _not_ letting the pin float, so it kinda seems like this is the better option. 
 
# Rollback steps
 - revert this branch
