### PR TITLE
Added BATCH message.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,10 @@ celerybeat-schedule
 venv/
 ENV/
 
+# Pipenv
+Pipfile
+Pipfile.lock
+
 # Spyder project settings
 .spyderproject
 

--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,7 @@ ENV/
 # Pipenv
 Pipfile
 Pipfile.lock
+pyproject.toml
 
 # Spyder project settings
 .spyderproject

--- a/singer/__init__.py
+++ b/singer/__init__.py
@@ -26,6 +26,7 @@ from singer.messages import (
     RecordMessage,
     SchemaMessage,
     StateMessage,
+    BatchMessage,
     format_message,
     parse_message,
     write_message,
@@ -34,6 +35,7 @@ from singer.messages import (
     write_schema,
     write_state,
     write_version,
+    write_batch
 )
 
 from singer.transform import (

--- a/singer/messages.py
+++ b/singer/messages.py
@@ -173,8 +173,9 @@ class BatchMessage(Message):
     The BATCH message has these fields:
 
       * stream (string) - The name of the stream.
-      * filepath (string) - The location of a batch file containing serialized records. e.g. '/tmp/users001.jsonl'.
-      * format (string, optional) - An indication of serialization format. If none is provided, 'jsonl' will be assumed. e.g. 'csv'.
+      * filepath (string) - The location of a batch file. e.g. '/tmp/users001.jsonl'.
+      * format (string, optional) - An indication of serialization format.
+            If none is provided, 'jsonl' will be assumed. e.g. 'csv'.
       * compression (string, optional) - An indication of file compression format. e.g. 'gzip'.
       * batch_size (int, optional) - Number of records in this batch. e.g. 100000.
 
@@ -191,10 +192,10 @@ class BatchMessage(Message):
 
     """
 
-    def __init__(self, stream, filepath, format=None, compression=None, batch_size=None):
+    def __init__(self, stream, filepath, file_format=None, compression=None, batch_size=None):
         self.stream = stream
         self.filepath = filepath
-        self.format = format or 'jsonl'
+        self.format = file_format or 'jsonl'
         self.compression = compression
         self.batch_size = batch_size
 
@@ -263,7 +264,7 @@ def parse_message(msg):
     elif msg_type == 'BATCH':
         return BatchMessage(stream=_required_key(obj, 'stream'),
                             filepath=_required_key(obj, 'filepath'),
-                            format=_required_key(obj, 'format'),
+                            file_format=_required_key(obj, 'format'),
                             compression=obj.get('compression'),
                             batch_size=obj.get('batch_size'))
 
@@ -340,15 +341,15 @@ def write_version(stream_name, version):
     write_message(ActivateVersionMessage(stream_name, version))
 
 def write_batch(
-    stream_name, filepath, format=None,
+    stream_name, filepath, file_format=None,
     compression=None, batch_size=None
 ):
     """Write a batch message.
 
     stream = 'users'
     filepath = '/tmp/users0001.jsonl'
-    format = 'jsonl'
+    file_format = 'jsonl'
     compression = None
     batch_size = 100000
     """
-    write_message(BatchMessage(stream_name, filepath, format, compression, batch_size))
+    write_message(BatchMessage(stream_name, filepath, file_format, compression, batch_size))

--- a/tests/test_singer.py
+++ b/tests/test_singer.py
@@ -90,6 +90,15 @@ class TestSinger(unittest.TestCase):
         with self.assertRaises(Exception):
             singer.parse_message('{"type": "STATE"}')
 
+    def test_parse_message_batch_good(self):
+        message = singer.parse_message(
+            '{"type": "BATCH", "stream": "users", "filepath": "/tmp/users0001.jsonl", "format": "jsonl"}')
+        self.assertEqual(message, singer.BatchMessage(stream='users', filepath='/tmp/users0001.jsonl'))
+
+    def test_parse_message_batch_missing_value(self):
+        with self.assertRaises(Exception):
+            singer.parse_message('{"type": "BATCH"}')
+
     def test_round_trip(self):
         record_message = singer.RecordMessage(
             record={'name': 'foo'},
@@ -112,7 +121,6 @@ class TestSinger(unittest.TestCase):
                          singer.parse_message(singer.format_message(state_message)))
 
     ## These three tests just confirm that writing doesn't throw
-
     def test_write_record(self):
         singer.write_record("users", {"name": "mike"})
 
@@ -124,6 +132,10 @@ class TestSinger(unittest.TestCase):
 
     def test_write_state(self):
         singer.write_state({"foo": 1})
+
+    def test_write_batch(self):
+        singer.write_batch("users", "/tmp/users0001.jsonl")
+
 
 class TestParsingNumbers(unittest.TestCase):
     def create_record(self, value):


### PR DESCRIPTION
# Description of change
As per this [issue](https://gitlab.com/meltano/meltano/-/issues/2364)

Adds a new BATCH message type to improve throughput between Tap and Target. BATCH messages have the following structure:

```json
{
  "type": "BATCH",
  "stream": "users",
  "filepath": "/tmp/users001.jsonl",
  "format": "jsonl",
  "compression": null,
  "batch_size": 100000
}
```

An example batch file (e.g. `/tmp/users0001.jsonl`) might contain the following records:
```json
{"type": "RECORD", "stream": "users", "version": 1, "time_extracted":  "2017-11-20T16:45:33.000Z", "record": {"id":1,"name":"Jack","father":"Mark","mother":"Charlotte","children":["Tom"]}}
{"type": "RECORD", "stream": "users", "version": 1, "time_extracted":  "2017-11-20T16:45:33.000Z", "record": {"id":2,"name":"Jill","father":"John","mother":"Ann","children":["Jessika","Antony","Jack"]}}
{"type": "RECORD", "stream": "users", "version": 1, "time_extracted":  "2017-11-20T16:45:33.000Z", "record": {"id":3,"name":"Fido","father":"Bob","mother":"Monika","children":["Jerry","Karol"]}}
```

# Manual QA steps
- peer reviewed internally (tails.com)
- added new tests and made sure they passed
- ran full test suite

# Risks
 - For now it is the Tap developers responsibility to handle the writing of valid records into a JSONL file. We might like to add some helper functions in this library to make this easier.
 
# Rollback steps
 - revert this branch