### PR TITLE
[AP-1060] Use orjson

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,4 +36,4 @@ jobs:
         run: pylint singer
 
       - name: Runs tests with coverage
-        run: nosetests --with-doctest -v 
+        run: nosetests --with-doctest -v --nocapture

--- a/pylintrc
+++ b/pylintrc
@@ -322,7 +322,7 @@ ignore-mixin-members=yes
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis. It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=
+ignored-modules=orjson
 
 # List of classes names for which member attributes should not be checked
 # (useful for classes with attributes dynamically set). This supports can work

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(name="pipelinewise-singer-python",
       install_requires=[
           'pytz<2021.0',
           'jsonschema==3.2.0',
-          'orjson==3.6.4',
+          'orjson==3.6.1',
           'python-dateutil>=2.6.0',
           'backoff==1.10.0',
           'ciso8601',

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(name="pipelinewise-singer-python",
       install_requires=[
           'pytz<2021.0',
           'jsonschema==3.2.0',
-          'simplejson==3.17.2',
+          'orjson==3.6.4',
           'python-dateutil>=2.6.0',
           'backoff==1.10.0',
           'ciso8601',

--- a/singer/catalog.py
+++ b/singer/catalog.py
@@ -125,7 +125,7 @@ class Catalog():
         return {'streams': [stream.to_dict() for stream in self.streams]}
 
     def dump(self):
-        write_catalog(self.to_dict())
+        write_catalog(self)
 
     def get_stream(self, tap_stream_id):
         for stream in self.streams:

--- a/singer/catalog.py
+++ b/singer/catalog.py
@@ -1,5 +1,5 @@
 '''Provides an object model for a Singer Catalog.'''
-import json
+import orjson
 import sys
 
 from . import metadata as metadata_module
@@ -15,7 +15,9 @@ def write_catalog(catalog):
     if not catalog.streams:
         LOGGER.warning('Catalog being written with no streams.')
 
-    json.dump(catalog.to_dict(), sys.stdout, indent=2)
+    catalog_json = orjson.dumps(catalog.to_dict(), option=orjson.OPT_INDENT_2)
+    sys.stdout.buffer.write(catalog_json)
+    sys.stdout.buffer.flush()
 
 # pylint: disable=too-many-instance-attributes
 class CatalogEntry():
@@ -93,7 +95,7 @@ class Catalog():
     @classmethod
     def load(cls, filename):
         with open(filename, encoding='utf-8') as fp:  # pylint: disable=invalid-name
-            return Catalog.from_dict(json.load(fp))
+            return Catalog.from_dict(orjson.loads(fp.read()))
 
     @classmethod
     def from_dict(cls, data):
@@ -123,7 +125,7 @@ class Catalog():
         return {'streams': [stream.to_dict() for stream in self.streams]}
 
     def dump(self):
-        json.dump(self.to_dict(), sys.stdout, indent=2)
+        write_catalog(self.to_dict())
 
     def get_stream(self, tap_stream_id):
         for stream in self.streams:

--- a/singer/messages.py
+++ b/singer/messages.py
@@ -1,7 +1,7 @@
 import sys
 
 import pytz
-import simplejson as json
+import orjson
 import ciso8601
 
 import singer.utils as u
@@ -239,7 +239,7 @@ def parse_message(msg):
     # lossy conversions.  However, this will affect
     # very few data points and we have chosen to
     # leave conversion as is for now.
-    obj = json.loads(msg, use_decimal=True)
+    obj = orjson.loads(msg)
     msg_type = _required_key(obj, 'type')
 
     if msg_type == 'RECORD':
@@ -293,12 +293,12 @@ def parse_message(msg):
 
 
 def format_message(message):
-    return json.dumps(message.asdict(), use_decimal=True)
+    return orjson.dumps(message.asdict(), option=orjson.OPT_APPEND_NEWLINE)
 
 
 def write_message(message):
-    sys.stdout.write(format_message(message) + '\n')
-    sys.stdout.flush()
+    sys.stdout.buffer.write(format_message(message))
+    sys.stdout.buffer.flush()
 
 
 def write_record(stream_name, record, stream_alias=None, time_extracted=None):

--- a/singer/metrics.py
+++ b/singer/metrics.py
@@ -40,7 +40,7 @@ commonly used metrics.
 
 '''
 
-import json
+import orjson
 import re
 import time
 from collections import namedtuple
@@ -84,7 +84,7 @@ def log(logger, point):
         'value': point.value,
         'tags': point.tags
     }
-    logger.info('METRIC: %s', json.dumps(result))
+    logger.info('METRIC: %s', orjson.dumps(result))
 
 
 class Counter():
@@ -237,7 +237,7 @@ def parse(line):
     if match:
         json_str = match.group(1)
         try:
-            raw = json.loads(json_str)
+            raw = orjson.loads(json_str)
             return Point(
                 metric_type=raw.get('type'),
                 metric=raw.get('metric'),

--- a/singer/schema.py
+++ b/singer/schema.py
@@ -57,7 +57,7 @@ class Schema():  # pylint: disable=too-many-instance-attributes
         self.patternProperties = patternProperties
 
     def __str__(self):
-        return orjson.dumps(self.to_dict())
+        return orjson.dumps(self.to_dict()).decode('utf-8')
 
     def __repr__(self):
         pairs = [k + '=' + repr(v) for k, v in self.__dict__.items()]

--- a/singer/schema.py
+++ b/singer/schema.py
@@ -1,7 +1,7 @@
 # pylint: disable=redefined-builtin, too-many-arguments, invalid-name
 '''Provides an object model for JSON Schema'''
 
-import json
+import orjson
 
 # These are standard keys defined in the JSON Schema spec
 STANDARD_KEYS = [
@@ -57,7 +57,7 @@ class Schema():  # pylint: disable=too-many-instance-attributes
         self.patternProperties = patternProperties
 
     def __str__(self):
-        return json.dumps(self.to_dict())
+        return orjson.dumps(self.to_dict())
 
     def __repr__(self):
         pairs = [k + '=' + repr(v) for k, v in self.__dict__.items()]

--- a/singer/utils.py
+++ b/singer/utils.py
@@ -2,7 +2,7 @@ import argparse
 import collections
 import datetime
 import functools
-import json
+import orjson
 import time
 from warnings import warn
 
@@ -106,7 +106,7 @@ def chunk(array, num):
 
 def load_json(path):
     with open(path, encoding='utf-8') as fil:
-        return json.load(fil)
+        return orjson.loads(fil.read())
 
 
 def update_state(state, entity, dtime):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -43,6 +43,9 @@ class TestSchema(unittest.TestCase):
                         inclusion='whatever',
                         additionalProperties=True)
 
+    def test_to_string(self):
+        self.assertEquals('{"maxLength":32,"type":"string"}', str(self.string_obj))
+
     def test_string_to_dict(self):
         self.assertEquals(self.string_dict, self.string_obj.to_dict())
 

--- a/tests/test_singer.py
+++ b/tests/test_singer.py
@@ -1,8 +1,7 @@
 import singer
+import orjson
 import unittest
-import datetime
 import dateutil
-from decimal import Decimal
 
 
 class TestSinger(unittest.TestCase):
@@ -153,26 +152,25 @@ class TestParsingNumbers(unittest.TestCase):
 
     def test_parse_regular_decimal(self):
         value = self.create_record('3.14')
-        self.assertEqual(Decimal('3.14'), value)
+        self.assertEqual(3.14, value)
 
     def test_parse_large_decimal(self):
         value = self.create_record('9999999999999999.9999')
-        self.assertEqual(Decimal('9999999999999999.9999'), value)
+        self.assertEqual(9999999999999999.9999, value)
 
     def test_parse_small_decimal(self):
         value = self.create_record('-9999999999999999.9999')
-        self.assertEqual(Decimal('-9999999999999999.9999'), value)
+        self.assertEqual(-9999999999999999.9999, value)
 
     def test_parse_absurdly_large_decimal(self):
         value_str = '9' * 1024 + '.' + '9' * 1024
-        value = self.create_record(value_str)
-        self.assertEqual(Decimal(value_str), value)
+        with self.assertRaises(orjson.JSONDecodeError):
+            self.create_record(value_str)
 
     def test_parse_absurdly_large_int(self):
         value_str = '9' * 1024
-        value = self.create_record(value_str)
-        self.assertEqual(int(value_str), value)
-        self.assertEqual(int, type(value))
+        with self.assertRaises(orjson.JSONDecodeError):
+            self.create_record(value_str)
 
     def test_parse_bulk_decs(self):
         value_strs = [
@@ -192,7 +190,7 @@ class TestParsingNumbers(unittest.TestCase):
         ]
         for value_str in value_strs:
             value = self.create_record(value_str)
-            self.assertEqual(Decimal(value_str), value)
+            self.assertEqual(float(value_str), value)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# Description of change

Taps and targets are using python-builtin and simplejson JSON libraries. We'd like to improve the overall performance of [tap-kafka](https://github.com/transferwise/pipelinewise-tap-kafka) and the JSON operations are done by this package.

This PR is refactoring the code to use [orjson](https://github.com/ijl/orjson) which overperforms and benchmarked as the fastest JSON library:
* https://github.com/ijl/orjson#performance
* https://github.com/ultrajson/ultrajson#benchmarks
* https://levelup.gitconnected.com/json-encoding-decoding-with-python-62a2cae63a6a


# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
