### PR TITLE
Fix format message not returning newline

### DIFF
--- a/singer/messages.py
+++ b/singer/messages.py
@@ -292,12 +292,12 @@ def parse_message(msg):
     return None
 
 
-def format_message(message):
-    return orjson.dumps(message.asdict(), option=orjson.OPT_APPEND_NEWLINE)
+def format_message(message, option=0):
+    return orjson.dumps(message.asdict(), option=option)
 
 
 def write_message(message):
-    sys.stdout.buffer.write(format_message(message))
+    sys.stdout.buffer.write(format_message(message, option=orjson.OPT_APPEND_NEWLINE))
     sys.stdout.buffer.flush()
 
 

--- a/tests/test_singer.py
+++ b/tests/test_singer.py
@@ -200,6 +200,12 @@ class TestParsingNumbers(unittest.TestCase):
         self.assertEqual(b'{"type":"RECORD","stream":"users","record":{"name":"foo"}}',
                          singer.format_message(record_message))
 
+        self.assertEqual(b'{"type":"RECORD","stream":"users","record":{"name":"foo"}}',
+                         singer.format_message(record_message, option=0))
+
+        self.assertEqual(b'{"type":"RECORD","stream":"users","record":{"name":"foo"}}\n',
+                         singer.format_message(record_message, option=orjson.OPT_APPEND_NEWLINE))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_singer.py
+++ b/tests/test_singer.py
@@ -192,6 +192,14 @@ class TestParsingNumbers(unittest.TestCase):
             value = self.create_record(value_str)
             self.assertEqual(float(value_str), value)
 
+    def test_format_message(self):
+        record_message = singer.RecordMessage(
+            record={'name': 'foo'},
+            stream='users')
+
+        self.assertEqual(b'{"type":"RECORD","stream":"users","record":{"name":"foo"}}',
+                         singer.format_message(record_message))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
# Description of change

`format_message` function should not append newline to the end of returned bytes.

Sometimes this functions used directly by downstream apps and causing issues when parsing it. Newline character should be appended only when writing to `stdout` by `write_message`.

This behaviour is in sync with the previous [1.x](https://github.com/transferwise/pipelinewise-singer-python/blob/fcae917c44cefc085c15a52b876ced3e940eb39e/singer/messages.py#L297
) version of this library.
# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
