### PR TITLE
Drop support for Python 3.6

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checking out repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,9 +29,6 @@ jobs:
           python -m pip install -U pip setuptools wheel
           python3 -m pip install -U .[dev]
 
-      - name: Check code formatting
-        run: find singer tests -type f -name '*.py' | xargs unify --check-only
-
       - name: Analysing the code with pylint
         run: pylint singer
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,4 +34,42 @@ jobs:
         run: pylint singer
 
       - name: Runs tests with coverage
-        run: pytest
+        run: coverage run --parallel -m pytest
+
+      - name: Upload coverage data
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-data
+          path: ".coverage.*"
+
+  coverage:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+    - name: Check out the repository
+      uses: actions/checkout@v3
+
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.8"
+
+    - name: Install and upgrade dependencies
+      run: |
+        python -m pip install -U pip setuptools wheel
+        python3 -m pip install -U .[dev]
+
+    - name: Download coverage data
+      uses: actions/download-artifact@v3.0.0
+      with:
+        name: coverage-data
+
+    - name: Combine coverage data and display human readable report
+      run: |
+        coverage combine
+        coverage xml
+        coverage report
+
+    # Optional if you want to use codecov.io
+    # - name: Upload coverage report
+    #   uses: codecov/codecov-action@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,8 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+  workflow_dispatch:
+    inputs: {}
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,18 +8,18 @@ on:
 
 jobs:
   build:
-    
+
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
-    
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
+
     runs-on: ubuntu-latest
 
     steps:
       - name: Checking out repo
         uses: actions/checkout@v2
 
-      - name: Set up Python ${{ matrix.container[1] }}
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,10 +66,16 @@ jobs:
       with:
         name: coverage-data
 
-    - name: Combine coverage data and display human readable report
+    - name: Combine coverage data
       run: |
         coverage combine
+
+    - name: Generate XML coverage report
+      run: |
         coverage xml
+
+    - name: Display human readable report
+      run: |
         coverage report
 
     # Optional if you want to use codecov.io

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,4 +34,4 @@ jobs:
         run: pylint singer
 
       - name: Runs tests with coverage
-        run: nosetests --with-doctest -v --nocapture
+        run: pytest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ jobs:
   build:
 
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
 

--- a/.gitignore
+++ b/.gitignore
@@ -86,7 +86,6 @@ ENV/
 # Pipenv
 Pipfile
 Pipfile.lock
-pyproject.toml
 
 # Spyder project settings
 .spyderproject

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,35 @@
+# See https://pre-commit.com for more information
+
+# See https://pre-commit.ci/ for information about the continuous
+# integration service for the pre-commit framework 
+ci:
+    autofix_prs: false
+    autoupdate_schedule: weekly
+    autoupdate_commit_msg: 'chore(deps): pre-commit autoupdate'
+
+
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.2.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-added-large-files
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v2.32.0
+    hooks:
+    -   id: pyupgrade
+        name: pyupgrade (python)
+        args: [--py37-plus]
+-   repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+    -   id: isort
+        name: isort (python)
+-   repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+    -   id: black
+        name: black (python)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 # See https://pre-commit.com for more information
 
 # See https://pre-commit.ci/ for information about the continuous
-# integration service for the pre-commit framework 
+# integration service for the pre-commit framework
 ci:
     autofix_prs: false
     autoupdate_schedule: weekly
@@ -33,3 +33,8 @@ repos:
     hooks:
     -   id: black
         name: black (python)
+-   repo: https://github.com/PyCQA/pylint
+    rev: v2.13.8
+    hooks:
+    -   id: pylint
+        name: pylint (python)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,7 @@
 
 ## Submitting a PR
 
-1. Write tests to cover any new code or code changes.
-2. Please make sure that all tests pass and that the code passes linting with `make`.
-3. Open up the PR.
+1. Install and use [pre-commit](https://pre-commit.com/) to keep your changes in the style of the project.
+2. Write tests to cover any new code or code changes.
+3. Please make sure that all tests pass and that the code passes linting with `make`.
+4. Open up the PR.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,9 @@ source = ["singer", "*/site-packages"]
 branch = true
 source = ["singer"]
 
+[tool.coverage.report]
+fail_under = 76.0
+
 [tool.isort]
 profile = "black"
 multi_line_output = 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
-line-length = 88
+line-length = 120
 
 [tool.coverage.paths]
 source = ["singer", "*/site-packages"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[tool.black]
+line-length = 88
+
+[tool.isort]
+profile = "black"
+multi_line_output = 3
+src_paths = "singer"
+use_parentheses = true
+known_first_party = "singer"
+include_trailing_comma = true
+add_imports = [
+    "from __future__ import annotations",
+]
+
+[tool.pytest.ini_options]
+addopts = "-v --doctest-modules"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 line-length = 120
 
 [tool.coverage.paths]
-source = ["singer", "*/site-packages"]
+source = ["singer"]
 
 [tool.coverage.run]
 branch = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,13 @@
 [tool.black]
 line-length = 88
 
+[tool.coverage.paths]
+source = ["singer", "*/site-packages"]
+
+[tool.coverage.run]
+branch = true
+source = ["singer"]
+
 [tool.isort]
 profile = "black"
 multi_line_output = 3

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ setup(name="pipelinewise-singer-python",
               'coverage[toml]',
               'ipython',
               'ipdb',
-              'nose',
               'unify==0.5'
           ]
       },

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ with open("README.md", "r") as fh:
 setup(name="pipelinewise-singer-python",
       version='2.0.1',
       description="Singer.io utility library - PipelineWise compatible",
+      python_requires=">=3.7.0, <3.11",
       long_description=long_description,
       long_description_content_type="text/markdown",
       author="TransferWise",

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(name="pipelinewise-singer-python",
           'dev': [
               'pylint==2.11.1',
               'pytest==7.1.2',
-              'coverage[toml]',
+              'coverage[toml]~=6.3',
               'ipython',
               'ipdb',
               'unify==0.5'

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(name="pipelinewise-singer-python",
       install_requires=[
           'pytz',
           'jsonschema==3.2.0',
-          'orjson==3.6.1',
+          'orjson==3.6.5',
           'python-dateutil>=2.6.0',
           'backoff==1.11.1',
           'ciso8601',

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(name="pipelinewise-singer-python",
       extras_require={
           'dev': [
               'pylint==2.11.1',
+              'pytest==7.1.2',
               'ipython',
               'ipdb',
               'nose',

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(name="pipelinewise-singer-python",
           'dev': [
               'pylint==2.11.1',
               'pytest==7.1.2',
+              'coverage[toml]',
               'ipython',
               'ipdb',
               'nose',


### PR DESCRIPTION
# Description of change

- Drop support for Python 3.6 using `python_requires`.
- Replace `nose` with `pytest`.
- Set up `black` and `isort` configurations (not yet applied to any project files).
- Create `.pre-commit-config.yaml`.

# Manual QA steps
 
- Use `pytest`:

  ```
  python -m virtualenv venv
  source venv/bin/activate
  pytest
  ```

- I've used the [GitHub CLI](https://github.com/cli/cli/) successfully with the command `gh workflow run -r drop-python-3.6`. Example output: https://github.com/edgarrmondragon/pipelinewise-singer-python/actions/runs/2302679477
 
# Risks

 - Packages using this library and relying on Python 3.6 might face problems if they try to upgrade without similarly dropping support for 3.6.
 
# Rollback steps

 - Revert this branch

Closes #63