### PR TITLE
Bugfix: output decimal.Decimal as number not string to comply with JSONSchema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.2 (2022-03-23)
+ * Using orjson instead of simplejson or other serializers for speed benefit
+ * Fix: Output decimal.Decimal as int or float not str
+
 ## 2.0.1 (2021-11-23)
   * Fixed an issue when `format_message` returned newline character
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(name="pipelinewise-singer-python",
       install_requires=[
           'pytz',
           'jsonschema==3.2.0',
-          'orjson==3.7.2',
+          'orjson==3.8.0',
           'python-dateutil>=2.6.0',
           'backoff==2.1.2',
           'ciso8601',

--- a/singer/messages.py
+++ b/singer/messages.py
@@ -295,7 +295,7 @@ def parse_message(msg):
 def format_message(message, option=0):
     def default(obj):
         if isinstance(obj, decimal.Decimal):
-            return str(obj)
+            return int(obj) if float(obj).is_integer() else float(obj)
         raise TypeError
     
     return orjson.dumps(message.asdict(), option=option, default=default)

--- a/singer/messages.py
+++ b/singer/messages.py
@@ -297,10 +297,7 @@ def format_message(message, option=0):
             return str(obj)
         raise TypeError
     
-    try:
-        return orjson.dumps(message.asdict(), option=option, default=default)
-    except:
-        print(message.asdict())
+    return orjson.dumps(message.asdict(), option=option, default=default)
 
 def write_message(message):
     sys.stdout.buffer.write(format_message(message, option=orjson.OPT_APPEND_NEWLINE))

--- a/singer/messages.py
+++ b/singer/messages.py
@@ -296,7 +296,10 @@ def orjson_default(obj):
         return str(obj)
 
 def format_message(message, option=0):
-    return orjson.dumps(message.asdict(), option=option, default=orjson_default)
+    try:
+        return orjson.dumps(message.asdict(), option=option, default=orjson_default)
+    except:
+        print(message.asdict())
 
 def write_message(message):
     sys.stdout.buffer.write(format_message(message, option=orjson.OPT_APPEND_NEWLINE))

--- a/singer/messages.py
+++ b/singer/messages.py
@@ -2,6 +2,7 @@ import sys
 
 import pytz
 import orjson
+import decimal
 import ciso8601
 
 import singer.utils as u

--- a/singer/messages.py
+++ b/singer/messages.py
@@ -294,8 +294,6 @@ def parse_message(msg):
 def orjson_default(obj):
     if isinstance(obj, decimal.Decimal):
         return str(obj)
-    else:
-        raise TypeError
 
 def format_message(message, option=0):
     return orjson.dumps(message.asdict(), option=option, default=orjson_default)

--- a/singer/messages.py
+++ b/singer/messages.py
@@ -291,10 +291,13 @@ def parse_message(msg):
 
     return None
 
+def orjson_default(obj):
+    if isinstance(obj, decimal.Decimal):
+        return str(obj)
+    raise TypeError
 
 def format_message(message, option=0):
-    return orjson.dumps(message.asdict(), option=option)
-
+    return orjson.dumps(message.asdict(), option=option, default=orjson_default)
 
 def write_message(message):
     sys.stdout.buffer.write(format_message(message, option=orjson.OPT_APPEND_NEWLINE))

--- a/singer/messages.py
+++ b/singer/messages.py
@@ -291,13 +291,14 @@ def parse_message(msg):
 
     return None
 
-def orjson_default(obj):
-    if isinstance(obj, decimal.Decimal):
-        return str(obj)
-
 def format_message(message, option=0):
+    def default(obj):
+        if isinstance(obj, decimal.Decimal):
+            return str(obj)
+        raise TypeError
+    
     try:
-        return orjson.dumps(message.asdict(), option=option, default=orjson_default)
+        return orjson.dumps(message.asdict(), option=option, default=default)
     except:
         print(message.asdict())
 

--- a/singer/messages.py
+++ b/singer/messages.py
@@ -294,7 +294,8 @@ def parse_message(msg):
 def orjson_default(obj):
     if isinstance(obj, decimal.Decimal):
         return str(obj)
-    raise TypeError
+    else:
+        raise TypeError
 
 def format_message(message, option=0):
     return orjson.dumps(message.asdict(), option=option, default=orjson_default)


### PR DESCRIPTION
# Description of change
Bugfix: Previously the orjson 'default' handler function set `decimal.Decimal` types to str, which caused issues with targets that validate JSONSchema strictly. For example target-postgres uses JSONSchema validation, for which number as str is not allowed.

# Manual QA steps
 - Tested in local environment with different values for `decimal.Decimal` records
 
# Risks
 - Existing taps built on top of this variant will see a change to types in some record messages which could have unexpected results
 
# Rollback steps
 - revert this branch
