### PR TITLE
[AP-2998] Handle Decimal objects in format_messages 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Changelog
+## 3.0.2 (2026-04-22)
+  * Handler for Decimal object in message 
+
+## 3.0.1 (2026-04-21)
+  * Fixed PyPI publisher
+  
+## 3.0.0 (2026-04-20)
+  * Support for Python 3.12
 
 ## 2.0.1 (2021-11-23)
   * Fixed an issue when `format_message` returned newline character

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 ## 3.0.2 (2026-04-22)
-  * Handler for Decimal object in message 
+  * Handle Decimal objects in messages
 
 ## 3.0.1 (2026-04-21)
   * Fixed PyPI publisher

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name="pipelinewise-singer-python",
-      version='3.0.1',
+      version='3.0.2',
       description="Singer.io utility library - PipelineWise compatible",
       python_requires=">=3.12, <3.13",
       long_description=long_description,

--- a/singer/__init__.py
+++ b/singer/__init__.py
@@ -35,7 +35,8 @@ from singer.messages import (
     write_schema,
     write_state,
     write_version,
-    write_batch
+    write_batch,
+    handler_for_decimal_object
 )
 
 from singer.transform import (

--- a/singer/messages.py
+++ b/singer/messages.py
@@ -295,6 +295,7 @@ def parse_message(msg):
 def handler_for_decimal_object(obj):
     if isinstance(obj, decimal.Decimal):
         return float(obj)
+    raise TypeError
 
 def format_message(message, option=0):
     return orjson.dumps(message.asdict(), option=option, default=handler_for_decimal_object)

--- a/singer/messages.py
+++ b/singer/messages.py
@@ -3,6 +3,7 @@ import sys
 import pytz
 import orjson
 import ciso8601
+import decimal
 
 import singer.utils as u
 from .logger import get_logger
@@ -291,9 +292,12 @@ def parse_message(msg):
 
     return None
 
+def handler_for_decimal_object(obj):
+    if isinstance(obj, decimal.Decimal):
+        return float(obj)
 
 def format_message(message, option=0):
-    return orjson.dumps(message.asdict(), option=option)
+    return orjson.dumps(message.asdict(), option=option, default=handler_for_decimal_object)
 
 
 def write_message(message):

--- a/tests/test_singer.py
+++ b/tests/test_singer.py
@@ -2,6 +2,9 @@ import singer
 import orjson
 import unittest
 import dateutil
+import decimal
+
+from unittest.mock import MagicMock
 
 
 class TestSinger(unittest.TestCase):
@@ -205,6 +208,45 @@ class TestParsingNumbers(unittest.TestCase):
 
         self.assertEqual(b'{"type":"RECORD","stream":"users","record":{"name":"foo"}}\n',
                          singer.format_message(record_message, option=orjson.OPT_APPEND_NEWLINE))
+
+    def test_default_handler_decimal(self):
+        """Test that decimal.Decimal is converted to a string."""
+        d = decimal.Decimal("10.50")
+        result = singer.handler_for_decimal_object(d)
+        self.assertEqual(result, 10.50)
+        self.assertIsInstance(result, float)
+
+    def test_default_handler_error(self):
+        """Test that unsupported types still raise a TypeError."""
+        with self.assertRaises(TypeError):
+            singer.handler_for_decimal_object(range(5))
+
+    def test_format_message_with_decimals(self):
+        """Test that format_message correctly serializes a message containing decimals."""
+        # Mocking the message object
+        mock_message = MagicMock()
+        mock_message.asdict.return_value = {
+            "id": 1,
+            "price": decimal.Decimal("99.99"),
+            "status": "active"
+        }
+
+        # We expect the Decimal to become a string in the resulting bytes
+        expected_output = b'{"id":1,"price":99.99,"status":"active"}'
+
+        result = singer.format_message(mock_message)
+        self.assertEqual(result, expected_output)
+
+    def test_format_message_options(self):
+        """Test that orjson options (like appending a newline) work."""
+        mock_message = MagicMock()
+        mock_message.asdict.return_value = {"key": "val"}
+
+        # orjson.OPT_APPEND_NEWLINE is an integer bitmask
+        result = singer.format_message(mock_message, option=orjson.OPT_APPEND_NEWLINE)
+
+        # Should end with a newline byte (10)
+        self.assertTrue(result.endswith(b'\n'))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# Description of change
## Context

Because the new version uses orjson, it does not handle decimal objects in the message. 
This update adds a handler for decimal objects and convert them to float.

https://transferwise.atlassian.net/browse/AP-2998


